### PR TITLE
Randomize when API requests to the server are made during each minute.

### DIFF
--- a/lib/gpilot/boat.ex
+++ b/lib/gpilot/boat.ex
@@ -125,7 +125,7 @@ defmodule Gpilot.Boat do
 
   @impl GenServer
   def handle_info(:query_status, state) do
-    Process.send_after(self(), :query_status, 1000*(61+:rand.uniform(5)-DateTime.utc_now().second))
+    Process.send_after(self(), :query_status, 1000*(54+:rand.uniform(11)))
     new_status = get_new_status(state.key)
     if is_nil(state.boat_type) && not is_nil(new_status["race"]) do
       send(self(), :query_race)


### PR DESCRIPTION
This change spreads out API requests to the server uniformly over the
span of each minute. The "random" offset is computed from a hash of the
boat key, so for the same boat every subsequent request will always be
one minute after the previous one.