### PR TITLE
Use relative paths for web resource locations.

### DIFF
--- a/lib/gpilot/web/autopilot.ex
+++ b/lib/gpilot/web/autopilot.ex
@@ -21,7 +21,7 @@ defmodule Gpilot.Web.Autopilot do
          autopilot <- parse_autopilot(body)
     do
       Gpilot.Boat.set_autopilot(key, autopilot)
-      {:ok, :cowboy_req.reply(303, %{"Location" => "/boat/#{key}"}, "", req), opts}
+      {:ok, :cowboy_req.reply(303, %{"Location" => "../boat/#{key}"}, "", req), opts}
     else
       _other ->
         headers = %{"content-type" => "text/html"}

--- a/lib/gpilot/web/boat.ex
+++ b/lib/gpilot/web/boat.ex
@@ -115,7 +115,7 @@ defmodule Gpilot.Web.Boat do
     <> Html.input([{"id", "value"},{"name", "value"},{"type", "number"},{"value", status["courseWater"]}]) <> "&#176;<br>"
     <> Html.input([{"type", "submit"},{"value", "Change course"}])
     )
-    |> Html.form(method: "POST", action: "/course/#{key}")
+    |> Html.form(method: "POST", action: "../course/#{key}")
   end
 
   defp render_gates(status, key) do
@@ -152,7 +152,7 @@ defmodule Gpilot.Web.Boat do
         (  Html.input([{"id", "ordering"},{"name", "ordering"}, {"type", "hidden"}])
         <> Html.input([{"type", "submit"},{"value", "Submit ordering"},{"onclick", "submit_ordering();"}])
         )
-        |> Html.form(method: "POST", action: "/gates/#{key}")
+        |> Html.form(method: "POST", action: "../gates/#{key}")
 
       ]
       |> Html.div([{"id", "gates_div"}, {"style", "display:none;"}])
@@ -179,7 +179,7 @@ defmodule Gpilot.Web.Boat do
         Html.input([{"type", "submit"},{"value", "Set waypoints"}]),
       ]
       |> Html.div()
-      |> Html.form(method: "POST", action: "/waypoint/#{key}")
+      |> Html.form(method: "POST", action: "../waypoint/#{key}")
 
     checkbox_attrs =
       fn value,checked ->
@@ -202,7 +202,7 @@ defmodule Gpilot.Web.Boat do
         Html.input([{"type", "submit"}, {"value", "Set autopilot"}])
       ]
       |> Enum.join("")
-      |> Html.form(method: "POST", action: "/autopilot/#{key}")
+      |> Html.form(method: "POST", action: "../autopilot/#{key}")
 
     upload =
       [
@@ -210,7 +210,7 @@ defmodule Gpilot.Web.Boat do
         Html.input([{"type", "submit"}, {"value", "Upload GPX"}])
       ]
       |> Enum.join("")
-      |> Html.form(method: "POST", action: "/waypoint/#{key}/upload", enctype: "multipart/form-data")
+      |> Html.form(method: "POST", action: "../waypoint/#{key}/upload", enctype: "multipart/form-data")
 
     [
       Html.h2("Autopilot"),

--- a/lib/gpilot/web/course.ex
+++ b/lib/gpilot/web/course.ex
@@ -22,7 +22,7 @@ defmodule Gpilot.Web.Course do
          {h, ""} <- Integer.parse(v),
          :ok <- Gpilot.Boat.change_course(key, h)
     do
-      headers = %{"Location" => "/boat/#{key}"}
+      headers = %{"Location" => "../boat/#{key}"}
       req = :cowboy_req.reply(303, headers, <<>>, req)
       {:ok, req, opts}
     else

--- a/lib/gpilot/web/gates.ex
+++ b/lib/gpilot/web/gates.ex
@@ -28,7 +28,7 @@ defmodule Gpilot.Web.Gates do
         |> Enum.sort(fn {i,_},{j,_} -> i<=j end)
         |> Enum.map(fn {_,x} -> x end)
       Gpilot.Boat.set_gates_ordering(key, gates_ordering)
-      {:ok, :cowboy_req.reply(303, %{"Location" => "/boat/#{key}"}, "", req), opts}
+      {:ok, :cowboy_req.reply(303, %{"Location" => "../boat/#{key}"}, "", req), opts}
     else
       _other ->
         headers = %{"content-type" => "text/html"}

--- a/lib/gpilot/web/waypoint.ex
+++ b/lib/gpilot/web/waypoint.ex
@@ -21,7 +21,7 @@ defmodule Gpilot.Web.Waypoint do
          waypoints <- parse_waypoints(body)
     do
       Gpilot.Boat.set_waypoints(key, waypoints)
-      {:ok, :cowboy_req.reply(303, %{"Location" => "/boat/#{key}"}, "", req), opts}
+      {:ok, :cowboy_req.reply(303, %{"Location" => "../boat/#{key}"}, "", req), opts}
     else
       _other ->
         headers = %{"content-type" => "text/html"}

--- a/lib/gpilot/web/waypoint_upload.ex
+++ b/lib/gpilot/web/waypoint_upload.ex
@@ -23,7 +23,7 @@ defmodule Gpilot.Web.WaypointUpload do
          {:ok, waypoints} <- extract_waypoints(data)
     do
       Gpilot.Boat.set_waypoints(key, waypoints)
-      {:ok, :cowboy_req.reply(303, %{"Location" => "/boat/#{key}"}, "", req), opts}
+      {:ok, :cowboy_req.reply(303, %{"Location" => "../boat/#{key}"}, "", req), opts}
     else
       _ ->
         {:ok, :cowboy_req.reply(400, Html.content_type(), "Bad request\n", req), opts}


### PR DESCRIPTION
Having relative paths allows for easier proxying and URL rewriting when
using a reverse proxy in front of gpilot. This is best accomplished by not
assuming that the root path "/" (from the client's point of view) always
belongs to the gpilot web service.