### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM elixir:1.9-slim
+
+EXPOSE 8080
+
+COPY . /opt/gpilot
+WORKDIR /opt/gpilot
+ENTRYPOINT ["sh","docker-entrypoint.sh"]
+
+

--- a/README.md
+++ b/README.md
@@ -8,8 +8,20 @@ Tested on a debian with Elixir 1.9, and Erlang 21, 22 and 23
 
 ## Install
 
+### Local Install (Debian)
+
 Clone this repo in /opt/gpilot
 Then run setup.sh to compile and install as a systemd service
+
+### Using Docker
+
+Clone this repo somewhere on our host machine.
+
+```bash
+cd <repo directory>
+docker build gpilot . 
+docker run -p 8080:8080 gpilot
+```
 
 ## Configuration
 
@@ -27,18 +39,15 @@ Description of available runtime options:
 
 You can start/stop the monitoring of an existing boat by
 visiting
-- your_host_ip:8080/new/your_boat_key
-- your_host_ip:8080/del/your_boat_key
+- http://localhost:8080/new/your_boat_key
+- http://localhost:8080/del/your_boat_key
 
 If, for any reason, the service is restarted, the list of boat process is persisted and all restarts automatically.
 If you want to clear all data, remove /opt/gpilot/database.ets when the service is stopped.
 
 ## Controlling a boat
 
-After the process is started, the boat page is available at
-```
-your_host_ip:8080/boat/your_boat_key
-```
+After the process is started, the boat page is available at `http://localhost:8080/boat/your_boat_key`
 
 where you will see the position, a wind graph with the latest wind data.
 On the wind graph, 6 angles are displayed:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+export HOME=/opt/gpilot
+export MIX_ENV=prod
+set -e
+mix local.hex --force
+mix local.rebar --force
+mix deps.get
+mix compile
+
+elixir --sname rc-$HOSTNAME --cookie gpilotcookie -S mix run --no-halt


### PR DESCRIPTION
Basic setup to make the application easily run using Docker on essentially any OS. I wanted this for myself - I'm on a Mac, this was the easiest way for me to get it to run.

I used `elixir:1.19-slim` container as base because the README indicated that gpilot had been tested on Debian with Elixir 1.9.

I updated the readme to include build and run instructions. I also changed the example URLs to use `localhost` because it's it should always work, and is easier than suggesting someone determine their local IP. 

I'm running this in Docker currently, so it does function. Some improvements could be made if it was desirable to have persistence for the container, but this was not so important to me. I mostly was just hoping to try gpilot out on my machine. 

Cheers,
Leo